### PR TITLE
Fix boost dependencies

### DIFF
--- a/src/chemkit/CMakeLists.txt
+++ b/src/chemkit/CMakeLists.txt
@@ -4,11 +4,13 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_SOURCE_DI
 find_package(Chemkit)
 include_directories(${CHEMKIT_INCLUDE_DIRS})
 
-find_package(Boost COMPONENTS system filesystem thread REQUIRED)
+find_package(Boost REQUIRED)
 
 # boost.thread in versions 1.50 and later require boost.chrono
 if(${Boost_VERSION} GREATER 104999)
-  find_package(Boost COMPONENTS chrono REQUIRED)
+  find_package(Boost COMPONENTS system filesystem thread chrono REQUIRED)
+else()
+  find_package(Boost COMPONENTS system filesystem thread REQUIRED)
 endif()
 
 set(HEADERS


### PR DESCRIPTION
This patch fixes the dependency issue caused by chemkit_LIB_DEPENDS that is overwritten with -lboost_chrono only, lacking -lboost_filesystem etc.