### PR TITLE
Workaround for moc and boost issue

### DIFF
--- a/src/chemkit/atom.h
+++ b/src/chemkit/atom.h
@@ -40,10 +40,12 @@
 
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/function.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/iterator/filter_iterator.hpp>
 #include <boost/iterator/transform_iterator.hpp>
+#endif
 
 #include "point3.h"
 #include "element.h"

--- a/src/chemkit/bitset.h
+++ b/src/chemkit/bitset.h
@@ -38,7 +38,9 @@
 
 #include "chemkit.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/dynamic_bitset.hpp>
+#endif
 
 namespace chemkit {
 

--- a/src/chemkit/bond.h
+++ b/src/chemkit/bond.h
@@ -40,9 +40,11 @@
 
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/function.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/iterator/filter_iterator.hpp>
+#endif
 
 #include "point3.h"
 #include "vector3.h"

--- a/src/chemkit/bondpredictor.h
+++ b/src/chemkit/bondpredictor.h
@@ -40,7 +40,9 @@
 
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/tuple/tuple.hpp>
+#endif
 
 #include "bond.h"
 

--- a/src/chemkit/cartesiancoordinates.h
+++ b/src/chemkit/cartesiancoordinates.h
@@ -40,7 +40,9 @@
 
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/array.hpp>
+#endif
 
 #include "matrix.h"
 #include "point3.h"

--- a/src/chemkit/chemkit.h
+++ b/src/chemkit/chemkit.h
@@ -38,8 +38,10 @@
 
 #include <cstddef>
 
+#ifndef Q_MOC_RUN
 #include <boost/config.hpp>
 #include <boost/preprocessor/stringize.hpp>
+#endif
 
 #include "config.h"
 

--- a/src/chemkit/concurrent.h
+++ b/src/chemkit/concurrent.h
@@ -38,7 +38,9 @@
 
 #include "chemkit.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/thread.hpp>
+#endif
 
 namespace chemkit {
 namespace concurrent {

--- a/src/chemkit/coordinatepredictor.h
+++ b/src/chemkit/coordinatepredictor.h
@@ -38,7 +38,9 @@
 
 #include "chemkit.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/thread/future.hpp>
+#endif
 
 namespace chemkit {
 

--- a/src/chemkit/delaunaytriangulation.h
+++ b/src/chemkit/delaunaytriangulation.h
@@ -40,7 +40,9 @@
 
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/array.hpp>
+#endif
 
 #include "point3.h"
 

--- a/src/chemkit/fingerprintsimilaritydescriptor.h
+++ b/src/chemkit/fingerprintsimilaritydescriptor.h
@@ -38,7 +38,9 @@
 
 #include "chemkit.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 #include "moleculardescriptor.h"
 

--- a/src/chemkit/foreach.h
+++ b/src/chemkit/foreach.h
@@ -38,7 +38,9 @@
 
 #include "chemkit.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/foreach.hpp>
+#endif
 
 #define foreach BOOST_FOREACH
 

--- a/src/chemkit/geometry.h
+++ b/src/chemkit/geometry.h
@@ -38,7 +38,9 @@
 
 #include "chemkit.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/array.hpp>
+#endif
 
 #include "point3.h"
 #include "vector3.h"

--- a/src/chemkit/molecularsurface.h
+++ b/src/chemkit/molecularsurface.h
@@ -38,7 +38,9 @@
 
 #include "chemkit.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/thread/future.hpp>
+#endif
 
 #include "point3.h"
 

--- a/src/chemkit/molecule-inline.h
+++ b/src/chemkit/molecule-inline.h
@@ -38,7 +38,9 @@
 
 #include "molecule.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/foreach.hpp>
+#endif
 
 namespace chemkit {
 

--- a/src/chemkit/molecule.h
+++ b/src/chemkit/molecule.h
@@ -42,7 +42,9 @@
 #include <string>
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/range/iterator_range.hpp>
+#endif
 
 #include "bitset.h"
 #include "point3.h"

--- a/src/chemkit/moleculeeditor.h
+++ b/src/chemkit/moleculeeditor.h
@@ -38,7 +38,9 @@
 
 #include "chemkit.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/signals2.hpp>
+#endif
 
 #include "molecule.h"
 

--- a/src/chemkit/moleculegraphtraits.h
+++ b/src/chemkit/moleculegraphtraits.h
@@ -38,10 +38,12 @@
 
 #include <utility>
 
+#ifndef Q_MOC_RUN
 #include <boost/graph/properties.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/property_map/property_map.hpp>
 #include <boost/type_traits/remove_reference.hpp>
+#endif
 
 #include "atom.h"
 #include "bond.h"

--- a/src/chemkit/moleculewatcher.h
+++ b/src/chemkit/moleculewatcher.h
@@ -38,7 +38,9 @@
 
 #include "chemkit.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/signals2/signal.hpp>
+#endif
 
 namespace chemkit {
 

--- a/src/chemkit/plugin.h
+++ b/src/chemkit/plugin.h
@@ -40,8 +40,10 @@
 
 #include <string>
 
+#ifndef Q_MOC_RUN
 #include <boost/function.hpp>
 #include <boost/lambda/construct.hpp>
+#endif
 
 namespace chemkit {
 

--- a/src/chemkit/pluginmanager.h
+++ b/src/chemkit/pluginmanager.h
@@ -41,7 +41,9 @@
 #include <string>
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/function.hpp>
+#endif
 
 namespace chemkit {
 

--- a/src/chemkit/ring.h
+++ b/src/chemkit/ring.h
@@ -40,10 +40,12 @@
 
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/function.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/iterator/counting_iterator.hpp>
 #include <boost/iterator/transform_iterator.hpp>
+#endif
 
 namespace chemkit {
 

--- a/src/chemkit/rppath.h
+++ b/src/chemkit/rppath.h
@@ -42,7 +42,9 @@
 #include <limits>
 #include <algorithm>
 
+#ifndef Q_MOC_RUN
 #include <boost/bind.hpp>
+#endif
 
 #include <Eigen/Core>
 

--- a/src/chemkit/structuresimilaritydescriptor.h
+++ b/src/chemkit/structuresimilaritydescriptor.h
@@ -38,7 +38,9 @@
 
 #include "chemkit.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 #include "moleculardescriptor.h"
 

--- a/src/chemkit/substructurequery.h
+++ b/src/chemkit/substructurequery.h
@@ -41,7 +41,9 @@
 #include <map>
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 #include "moiety.h"
 

--- a/src/chemkit/variant-inline.h
+++ b/src/chemkit/variant-inline.h
@@ -38,7 +38,9 @@
 
 #include "variant.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/lexical_cast.hpp>
+#endif
 
 namespace chemkit {
 

--- a/src/graphics/graphicsmolecularsurfaceitem.h
+++ b/src/graphics/graphicsmolecularsurfaceitem.h
@@ -38,7 +38,9 @@
 
 #include "graphics.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 #include "graphicsitem.h"
 

--- a/src/graphics/graphicsmoleculeitem.h
+++ b/src/graphics/graphicsmoleculeitem.h
@@ -38,7 +38,9 @@
 
 #include "graphics.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 #include <chemkit/molecule.h>
 #include <chemkit/atomcolormap.h>

--- a/src/graphics/graphicsmoleculewireframeitem.h
+++ b/src/graphics/graphicsmoleculewireframeitem.h
@@ -38,7 +38,9 @@
 
 #include "graphics.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 #include "graphicsitem.h"
 

--- a/src/graphics/graphicspymolsurfaceitem.h
+++ b/src/graphics/graphicspymolsurfaceitem.h
@@ -38,7 +38,9 @@
 
 #include "graphics.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 #include "graphicsitem.h"
 

--- a/src/graphics/graphicstool.h
+++ b/src/graphics/graphicstool.h
@@ -38,7 +38,9 @@
 
 #include "graphics.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 namespace chemkit {
 

--- a/src/graphics/graphicsview.h
+++ b/src/graphics/graphicsview.h
@@ -38,7 +38,9 @@
 
 #include "graphics.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 #include <chemkit/point3.h>
 

--- a/src/io/genericfile-inline.h
+++ b/src/io/genericfile-inline.h
@@ -40,6 +40,7 @@
 
 #include <fstream>
 #include <sstream>
+#ifndef Q_MOC_RUN
 #include <boost/format.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/scoped_ptr.hpp>
@@ -49,6 +50,7 @@
 #ifndef CHEMKIT_OS_WIN32
 #include <boost/iostreams/filter/gzip.hpp>
 #include <boost/iostreams/filter/bzip2.hpp>
+#endif
 #endif
 
 namespace chemkit {

--- a/src/io/genericfile.h
+++ b/src/io/genericfile.h
@@ -44,7 +44,9 @@
 #include <istream>
 #include <ostream>
 
+#ifndef Q_MOC_RUN
 #include <boost/iostreams/device/mapped_file.hpp>
+#endif
 
 #include <chemkit/variant.h>
 #include <chemkit/variantmap.h>

--- a/src/io/moleculefile.h
+++ b/src/io/moleculefile.h
@@ -41,8 +41,10 @@
 #include <string>
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
 #include <boost/range/iterator_range.hpp>
+#endif
 
 #include "genericfile.h"
 #include "moleculefileformat.h"

--- a/src/io/moleculefileformat.h
+++ b/src/io/moleculefileformat.h
@@ -43,7 +43,9 @@
 #include <istream>
 #include <ostream>
 
+#ifndef Q_MOC_RUN
 #include <boost/iostreams/device/mapped_file.hpp>
+#endif
 
 #include <chemkit/plugin.h>
 #include <chemkit/variant.h>

--- a/src/io/moleculefileformatadaptor-inline.h
+++ b/src/io/moleculefileformatadaptor-inline.h
@@ -38,8 +38,10 @@
 
 #include "moleculefileformatadaptor.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
+#endif
 
 #include <chemkit/polymer.h>
 #include <chemkit/lineformat.h>

--- a/src/io/polymerfile.h
+++ b/src/io/polymerfile.h
@@ -41,8 +41,10 @@
 #include <string>
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
 #include <boost/range/iterator_range.hpp>
+#endif
 
 #include "genericfile.h"
 #include "polymerfileformat.h"

--- a/src/io/polymerfileformat.h
+++ b/src/io/polymerfileformat.h
@@ -43,7 +43,9 @@
 #include <istream>
 #include <ostream>
 
+#ifndef Q_MOC_RUN
 #include <boost/iostreams/device/mapped_file.hpp>
+#endif
 
 #include <chemkit/plugin.h>
 

--- a/src/md-io/topologyfile.h
+++ b/src/md-io/topologyfile.h
@@ -38,7 +38,9 @@
 
 #include "md-io.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 #include <chemkit/genericfile.h>
 

--- a/src/md-io/topologyfileformat.h
+++ b/src/md-io/topologyfileformat.h
@@ -41,7 +41,9 @@
 #include <string>
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/iostreams/device/mapped_file.hpp>
+#endif
 
 #include <chemkit/plugin.h>
 

--- a/src/md-io/trajectoryfile.h
+++ b/src/md-io/trajectoryfile.h
@@ -40,7 +40,9 @@
 
 #include <string>
 
+#ifndef Q_MOC_RUN
 #include <boost/smart_ptr.hpp>
+#endif
 
 #include <chemkit/genericfile.h>
 

--- a/src/md-io/trajectoryfileformat.h
+++ b/src/md-io/trajectoryfileformat.h
@@ -43,7 +43,9 @@
 #include <istream>
 #include <ostream>
 
+#ifndef Q_MOC_RUN
 #include <boost/iostreams/device/mapped_file.hpp>
+#endif
 
 #include <chemkit/plugin.h>
 

--- a/src/md/forcefield.h
+++ b/src/md/forcefield.h
@@ -41,7 +41,9 @@
 #include <string>
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/thread/future.hpp>
+#endif
 
 #include <chemkit/plugin.h>
 #include <chemkit/point3.h>

--- a/src/md/forcefieldcalculation.h
+++ b/src/md/forcefieldcalculation.h
@@ -40,7 +40,9 @@
 
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 #include <chemkit/vector3.h>
 

--- a/src/md/integrator.h
+++ b/src/md/integrator.h
@@ -40,7 +40,9 @@
 
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 #include <chemkit/vector3.h>
 

--- a/src/md/moleculegeometryoptimizer.h
+++ b/src/md/moleculegeometryoptimizer.h
@@ -40,7 +40,9 @@
 
 #include <string>
 
+#ifndef Q_MOC_RUN
 #include <boost/thread/future.hpp>
+#endif
 
 namespace chemkit {
 

--- a/src/md/potential.h
+++ b/src/md/potential.h
@@ -40,7 +40,9 @@
 
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/thread/future.hpp>
+#endif
 
 #include <chemkit/vector3.h>
 

--- a/src/md/topology.h
+++ b/src/md/topology.h
@@ -41,8 +41,10 @@
 #include <string>
 #include <vector>
 
+#ifndef Q_MOC_RUN
 #include <boost/array.hpp>
 #include <boost/range/iterator_range.hpp>
+#endif
 
 namespace chemkit {
 

--- a/src/md/topologybuilder.h
+++ b/src/md/topologybuilder.h
@@ -40,7 +40,9 @@
 
 #include <string>
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 namespace chemkit {
 

--- a/src/plugins/mmff/mmffparameters.h
+++ b/src/plugins/mmff/mmffparameters.h
@@ -38,7 +38,9 @@
 
 #include <string>
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 #include "mmffaromaticitymodel.h"
 

--- a/src/plugins/mmff/mmffplugin.h
+++ b/src/plugins/mmff/mmffplugin.h
@@ -39,7 +39,9 @@
 #include <map>
 #include <string>
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 #include <chemkit/plugin.h>
 #include <chemkit/moleculardescriptor.h>

--- a/src/web/proteindatabank.h
+++ b/src/web/proteindatabank.h
@@ -40,7 +40,9 @@
 
 #include <QtCore>
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 namespace chemkit {
 

--- a/src/web/pubchem.h
+++ b/src/web/pubchem.h
@@ -40,7 +40,9 @@
 
 #include <string>
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 #include <QtCore>
 #include <QtNetwork>


### PR DESCRIPTION
This patch provides a workaround for the issue about MOC version < 5.0.0 and boost > 1.48.