### PR TITLE
Check if there exists a Path+1 and invert odd/even ring

### DIFF
--- a/src/chemkit/rppath.h
+++ b/src/chemkit/rppath.h
@@ -373,19 +373,18 @@ inline std::vector<std::vector<T> > rppath(const Graph<T> &graph)
             if(P(i, j).size() == 1 && Pt(i, j).size() == 0){
                 continue;
             }
+            
+            T size;
+
+            if(Pt(i, j).size() > 1){
+                size = 2 * D(i, j) + 1;
+            }
             else{
-                T size;
+                size = 2 * D(i, j);
+            }
 
-                if(P(i, j).size() > 1){
-                    size = 2 * D(i, j);
-                }
-                else{
-                    size = 2 * D(i, j) + 1;
-                }
-
-                if(size > 2){
-                    candidates.push_back(RingCandidate<T>(size, i, j));
-                }
+            if(size > 2){
+                candidates.push_back(RingCandidate<T>(size, i, j));
             }
         }
     }


### PR DESCRIPTION
The if line 379 should check if there is a Path+1 with a size > 1.
The odd and even ring was also inverted (based on the Supplementary Material algorithm of the RP-Path paper)

Warning: I didn't test or compiled the code !